### PR TITLE
Bugfix - allow vertical scrolling touch input with Inline Lightboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ## [1.7.0] - 2022-07-28
 
-- A few small bug fixes in situations where the `items` array may change size
-- Upgrade several dependencies
-    - "@react-spring/web": "9.5.2"
-    - "rollup": "^2.77.2",
+-   A few small bug fixes in situations where the `items` array may change size
+-   Upgrade several dependencies
+    -   "@react-spring/web": "9.5.2"
+    -   "rollup": "^2.77.2",
 
 ### Added
 
-- `Lightbox` can now be used as a slider component embedded in a page like slick-slider by using the `inline` prop
+-   `Lightbox` can now be used as a slider component embedded in a page like slick-slider by using the `inline` prop
 
 ## [1.6.0] - 2021-06-06
 

--- a/src/components/ImageStage/components/Image/index.tsx
+++ b/src/components/ImageStage/components/Image/index.tsx
@@ -286,6 +286,7 @@ const Image = ({
 
     return (
         <AnimatedImage
+            $inline={inline}
             className="lightbox-image"
             draggable="false"
             onClick={(e: React.MouseEvent<HTMLImageElement>) => {
@@ -317,12 +318,12 @@ Image.displayName = 'Image';
 
 export default Image;
 
-const AnimatedImage = styled(animated.img)`
+const AnimatedImage = styled(animated.img)<{ $inline: boolean }>`
     width: auto;
     height: auto;
     max-width: 100%;
     user-select: none;
-    touch-action: none;
+    touch-action: ${({ $inline }) => (!$inline ? 'none' : 'pan-y')};
     ::selection {
         background: none;
     }

--- a/src/components/ImageStage/components/ImagePager/index.tsx
+++ b/src/components/ImageStage/components/ImagePager/index.tsx
@@ -204,6 +204,7 @@ const ImagePager = ({
         <ImagePagerContainer>
             {pagerSprings.map(({ display, x }, i) => (
                 <AnimatedImagePager
+                    $inline={inline}
                     {...bind()}
                     className="lightbox-image-pager"
                     key={i}
@@ -227,6 +228,7 @@ const ImagePager = ({
                     <PagerContentWrapper>
                         <PagerInnerContentWrapper>
                             <ImageContainer
+                                $inline={inline}
                                 onClick={(e) => {
                                     e.stopPropagation();
                                     e.nativeEvent.stopImmediatePropagation();
@@ -272,7 +274,7 @@ const PagerContentWrapper = styled.div`
     justify-content: center;
 `;
 
-const AnimatedImagePager = styled(animated.div)`
+const AnimatedImagePager = styled(animated.div)<{ $inline: boolean }>`
     position: absolute;
     top: 0px;
     left: 0px;
@@ -281,16 +283,16 @@ const AnimatedImagePager = styled(animated.div)`
     height: 100%;
     width: 100%;
     will-change: transform;
-    touch-action: none;
+    touch-action: ${({ $inline }) => (!$inline ? 'none' : 'pan-y')};
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
 `;
 
-const ImageContainer = styled.div`
+const ImageContainer = styled.div<{ $inline: boolean }>`
     position: relative;
-    touch-action: none;
+    touch-action: ${({ $inline }) => (!$inline ? 'none' : 'pan-y')};
     user-select: none;
     display: flex;
     justify-content: center;


### PR DESCRIPTION
Allow vertical scrolling with an InlineLightbox on mobile (even while finger is over the image)